### PR TITLE
Bug fixes   

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .classpath
 .project
 .factorypath
+map.json

--- a/src/main/java/dk/aau/cs_24_sw_4_16/carl/Main.java
+++ b/src/main/java/dk/aau/cs_24_sw_4_16/carl/Main.java
@@ -43,7 +43,7 @@ public class Main {
             // The visit method walks the parse tree and constructs the AST
             AstNode astRoot = visitor.visit(tree);
             //System.out.println(astRoot);
-
+            
             SemanticChecker typeChecker = new SemanticChecker();
             typeChecker.visitor(astRoot);
             

--- a/src/main/java/dk/aau/cs_24_sw_4_16/carl/Semantic_A/SemanticChecker.java
+++ b/src/main/java/dk/aau/cs_24_sw_4_16/carl/Semantic_A/SemanticChecker.java
@@ -41,7 +41,7 @@ public class SemanticChecker {
     }
 
     public void visitor(AstNode node) {
-       /// System.out.println(node);
+        
         if (node instanceof ProgramNode) {
             visitProgramNode((ProgramNode) node);
         }
@@ -54,7 +54,7 @@ public class SemanticChecker {
     }
 
     public void visitStatements(StatementNode node) {
-        
+
         if (node.getNode() instanceof VariableDeclarationNode) {
             visitVariableDeclaration((VariableDeclarationNode) node.getNode());
         }
@@ -90,16 +90,19 @@ public class SemanticChecker {
             visitPropertyAssignment((PropertyAssignmentNode) node.getNode());
         }
         if (node.getNode() instanceof MethodCallNode) {
-            errorHandler("ewjrngkewgjewkejnweklrglewrkngewkrgkwen");
-            visitMethodCall((MethodCallNode) node.getNode());
+           // errorHandler("ewjrngkewgjewkejnweklrglewrkngewkrgkwen");
+            //visitMethodCall((MethodCallNode) node.getNode());
         }
     }
 
     public void errorHandler(String errorMessage) {
         thereWasAnError = true;
-        System.err.println("Error " + errorNumber);
-        errorNumber = errorNumber + 1;
-        System.err.println(errorMessage);
+        
+            System.err.println("Error " + errorNumber);
+            errorNumber = errorNumber + 1;
+            System.err.println(errorMessage);
+        
+
     }
 
     /*
@@ -146,17 +149,18 @@ public class SemanticChecker {
     public void visistArrayAssignment(ArrayAssignmentNode node) {
         String identifier = node.getIdentifier().toString();
         Boolean found = false;
-
+        Type arrayType = Type.UNKNOWN;
         found = scopes.getLast().containsKey(identifier);
 
-        // System.out.println(activeScope);
-        for (int i = activeScope.getLast(); i < scopes.size(); i++) {
+       
+        for (int i = scopes.size() - 1; 0 <= i; i--) {
+
             if (scopes.get(i).containsKey(identifier)) {
                 found = true;
+                arrayType = scopes.get(i).get(identifier);
             }
         }
         if (found) {
-            Type arrayType = scopes.getLast().get(identifier);
 
             Boolean validTypesaccesTypes = true;
             Type sizeType = Type.UNKNOWN;
@@ -216,7 +220,7 @@ public class SemanticChecker {
         for (int i = 0; i < sizes.size(); i++) {
             AstNode astNode = sizes.get(i);
             sizeType = getType(astNode);
-            if (sizeType != arrayType) {
+            if (sizeType != Type.INT) {
                 arguementNumber = i;
                 validTypes = false;
 
@@ -246,18 +250,10 @@ public class SemanticChecker {
         }
     }
 
-    // Ved ikke om den virker endnu, kan være det er forkert
+   
     public Type visitPropertyAccessNode(PropertyAccessNode node) {
         List<String> validPropertyAccess = new ArrayList<>(Arrays.asList("size", "get"));
-        // Viker ikke til det her behøves at tjekkes
-        // Type structType = getType(node.getList());
-        // System.out.println(structType);
-        //
-        // if (!structTypes.containsValue(structType)) {
-        // errorHandler("could not find the struct type: " + structType);
-        // return Type.UNKNOWN;
-        // }
-
+      
         String firstIdentifier = node.getIdentifiers().get(0).toString();
         if (!structVariablesTable.containsKey(firstIdentifier) && !validPropertyAccess.contains(firstIdentifier)) {
             errorHandler("could not find the struct variable: " + firstIdentifier);
@@ -278,15 +274,7 @@ public class SemanticChecker {
         return Type.UNKNOWN;
     }
 
-    public void visitMethodCall(MethodCallNode node) {
-        List<String> names = new ArrayList<>(structTypes.keySet());
-        try {
-            int i = Integer.parseInt(node.getValue().toString());
-           // System.out.println("Parsed integer value: " + i);
-        } catch (NumberFormatException e) {
-           // System.err.println("Error parsing integer: " + e.getMessage());
-        }
-    }
+   
 
     public Type relationOperatorTypeCheck(RelationsAndLogicalOperatorNode node) {
 
@@ -306,6 +294,10 @@ public class SemanticChecker {
         } else if (leftType == Type.BOOLEAN && rightType == Type.BOOLEAN) {
             return Type.BOOLEAN;
         }
+        else if (leftType == Type.STRING && rightType == Type.STRING) {
+            return Type.BOOLEAN;
+        }
+        
 
         errorHandler("Wrong types for relation operation:" + leftType + ":" + left + " And:" + right + ":" + rightType);
 
@@ -381,12 +373,11 @@ public class SemanticChecker {
     public Type getVariable(IdentifierNode node) {
 
         if (scopes.getLast().containsKey(node.getIdentifier().toString())) {
-            // System.out.println("234324234"+scopes.getFirst());
+           
             currentIdentifierCheck = node.getIdentifier().toString();
             return scopes.getLast().get(node.getIdentifier().toString());
         }
-        // System.out.println("We get in here:"+node.getIdentifier().toString());
-        // System.out.println("The scopes:"+scopes);
+      
         for (int i = activeScope.getLast(); i < scopes.size(); i++) {
             if (scopes.get(i).containsKey(node.getIdentifier().toString())) {
                 currentIdentifierCheck = node.getIdentifier().toString();
@@ -402,7 +393,7 @@ public class SemanticChecker {
     // Check if return = type er det samme som den function den står i.
     public void visitReturnNode(ReturnStatementNode node) {
         Type returnType = getType(node.getReturnValue());
-        // System.out.println(returnType);
+       
         if (currentActiveFunction == "") {
             errorHandler("You have made return statement outside a function THAT IS illigal");
         } else {
@@ -419,18 +410,14 @@ public class SemanticChecker {
     }
 
     public void visitAssignNode(AssignmentNode node) {
-        
+
         boolean foundIdentifier = false;
 
         for (int i = scopes.size() - 1; 0 <= i; i--) {
-            // System.out.println("This many scopes:" + i + ":" + scopes.get(i));
+           
             HashMap<String, Type> ETable = scopes.get(i);
-            // System.out.println("Scopes:"+scopes+"CurrentScopeWecheck:");
-            // System.out.println("Here it break2s"+ETable);
-            if (true) {
-                // System.out.println("Identifier" + node.getIdentifier().toString());
-                // System.out.println("Etable:" + ETable);
-            }
+          
+           
             if (ETable.containsKey(node.getIdentifier().toString())) {// hvis x er i scope
                 foundIdentifier = true;
                 // tjekke om det er lovligt.
@@ -492,12 +479,12 @@ public class SemanticChecker {
         HashMap<String, Type> localTable = new HashMap<>();
         scopes.add(localTable);
         visitBlockNode(node.getBlock());
-        System.out.println(localTable);
+     
         scopes.remove(localTable);
     }
 
     public void visitFunctionDefinition(FunctionDefinitionNode node) {
-        // System.out.println(node + "We get in here");
+       
         if (!listOfInbuiltFunctions.contains(node.getIdentifier().toString())) {
             if (!typeOfReturnFunction.containsKey(node.toString())
                     && !functionParameters.containsKey(node.toString())) {
@@ -528,8 +515,7 @@ public class SemanticChecker {
                 visitBlockNode(node.getBlock());// Alle statement i fn. En af dem er returnStatement
                 currentActiveFunction = "";
                 if (!hasReturnStatement && Type.VOID != getType(node.getReturnType())) {
-                   // System.out.println(getType(node.getReturnType()));
-                   // System.out.println(typeOfReturnFunction);
+                    
                     errorHandler("Missing return statement in function declartion:" + node.getIdentifier().toString());
                 }
                 hasReturnStatement = false;
@@ -550,7 +536,7 @@ public class SemanticChecker {
      * Vi skal sige hvis arguemtnet er en forkert type.
      */
     public void visitFunctionCall(FunctionCallNode node) {
-        // System.out.println("we get in here how?" + node);
+      
         if (!listOfInbuiltFunctions.contains(node.getFunctionName().toString())) {
 
             HashMap<String, Type> localETable = new HashMap<>();
@@ -654,6 +640,12 @@ public class SemanticChecker {
         }
     }
 
+    public Type resolveMethodCallType(MethodCallNode node) {
+        Type returnType = Type.INT;
+
+        return returnType;
+    }
+
     public Type getType(Object node) {
         Type type = Type.UNKNOWN;
 
@@ -671,7 +663,10 @@ public class SemanticChecker {
         } else if (node instanceof PropertyAccessNode) {
             type = visitPropertyAccessNode((PropertyAccessNode) node);
         } else if (node instanceof MethodCallNode) {
-            visitMethodCall((MethodCallNode) node);
+            MethodCallNode methodCallNode = (MethodCallNode) node;
+            type = resolveMethodCallType(methodCallNode);
+           
+           
         } else if (node instanceof BinaryOperatorNode) {
             type = binaryOperatorTypeCheck((BinaryOperatorNode) node);
         } else if (node instanceof RelationsAndLogicalOperatorNode) {
@@ -738,7 +733,8 @@ public class SemanticChecker {
                 default:
                     break;
             }
-        } else {
+        } 
+        else {
             errorHandler("The node we get failed to handle:" + node.getClass());
         }
         return type;


### PR DESCRIPTION
Type checker bug fixes
- [x] Program array må gerne være af type string, argumenter skal altid være af type int
- [x] Array Assignment gik tidligere ikke ingennem alle scopes for at prøve at finde variable. Fixet nu
- [x] Vi håndtere ikke cassen med method call, hvilket smider fejl når den bruges, fordi den(Gettype) ikke kan resolve typen.  var roomSize : int = room.size()
- [x] Relational operations kunne ikke håndere sammenligning mellem 2 strings.  kan nu